### PR TITLE
Fix 64-bit problem

### DIFF
--- a/include/LofarStMan/LofarStMan.h
+++ b/include/LofarStMan/LofarStMan.h
@@ -335,10 +335,10 @@ private:
   // The seqnr file (if present) is always memory-mapped because it is small.
   casacore::MMapIO*     itsSeqFile;
   bool   itsDoSwap;       //# True = byte-swapping is needed
-  casacore::uInt  itsBlockSize;    //# size of a block containing a seqnr
-  long  itsBLDataSize;   //# data size of a single baseline
-  long  itsDataStart;    //# start of data in a block
-  long  itsSampStart;    //# start of nsamples in a block
+  long long itsBlockSize;    //# size of a block containing a seqnr
+  long long itsBLDataSize;   //# data size of a single baseline
+  long long itsDataStart;    //# start of data in a block
+  long long itsSampStart;    //# start of nsamples in a block
   //# Buffer to hold nsample values.
   casacore::Block<casacore::uChar> itsNSampleBuf1;
   casacore::Block<casacore::uShort> itsNSampleBuf2;

--- a/src/LofarStMan.cc
+++ b/src/LofarStMan.cc
@@ -233,7 +233,7 @@ void LofarStMan::openFiles (bool writable)
   // Map the file with seqnrs.
   mapSeqFile();
   // Size the buffer if needed.
-  if (long(itsBuffer.size()) < itsBLDataSize) {
+  if ((long long) (itsBuffer.size()) < itsBLDataSize) {
     itsBuffer.resize (itsBLDataSize);
   }
   itsSpec.define ("useSeqnrFile", itsSeqFile!=0);
@@ -530,7 +530,7 @@ const uInt* LofarStMan::getNSample4 (uInt rownr, Bool)
 void* LofarStMan::readFile (uInt blocknr, uInt offset, uInt size)
 {
   AlwaysAssert (size <= itsBuffer.size(), AipsError);
-  itsRegFile->seek (Int(blocknr*itsBlockSize + offset));
+  itsRegFile->seek (blocknr*itsBlockSize + offset);
   itsRegFile->read (size, itsBuffer.storage());
   return itsBuffer.storage();
 }
@@ -544,7 +544,7 @@ void* LofarStMan::getBuffer (uInt size)
 void LofarStMan::writeFile (uInt blocknr, uInt offset, uInt size)
 {
   AlwaysAssert (size <= itsBuffer.size(), AipsError);
-  itsRegFile->seek (Int(blocknr*itsBlockSize + offset));
+  itsRegFile->seek (blocknr*itsBlockSize + offset);
   itsRegFile->write (size, itsBuffer.storage());
 }
 

--- a/test/tfix.cc
+++ b/test/tfix.cc
@@ -58,7 +58,7 @@ int main (int argc, char* argv[])
       return 0;
     }
     fixTable (argv[1]);
-  } catch (AipsError x) {
+  } catch (AipsError& x) {
     cout << "Caught an exception: " << x.getMesg() << endl;
     return 1;
   } 


### PR DESCRIPTION
I believe this fixes #1 . 

I've done a few fixes to make sure types are always large enough. I believe the specific issue causing this problem is in LofarStMan.cc:

```
  itsRegFile->seek (Int(blocknr*itsBlockSize + offset));
```
at lines 533 and 547. There should not be a cast to int there. With an int cast there, it limits indeed the size of the file to 31-bits. @tammojan did you add this Int cast? 

BTW At first I thought this had to do with casacore's 64-bit changes, but this is completely unrelated.