### PR TITLE
#10: Do not overwrite CMAKE_MODULE_PATH to support FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.5)
 
 project(LofarStMan VERSION 1.0)
 
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR})
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O3")
 
@@ -17,7 +17,6 @@ endif(PORTABLE)
 enable_testing()
 
 find_package(Casacore COMPONENTS casa measures tables REQUIRED)
-include_directories(${CASACORE_INCLUDE_DIR})
 
 add_library(lofarstman SHARED
   src/LofarStMan.cc
@@ -25,6 +24,10 @@ add_library(lofarstman SHARED
   src/Register.cc
 )
 
+target_include_directories(lofarstman
+	PRIVATE
+	${CASACORE_INCLUDE_DIR}
+)
 target_include_directories(lofarstman
 	PUBLIC
 	$<INSTALL_INTERFACE:include>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,12 +3,17 @@
 include_directories($<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 
 add_executable(tfix tfix.cc)
+target_include_directories(tfix PRIVATE ${CASACORE_INCLUDE_DIR})
 target_compile_features(tfix PRIVATE cxx_std_11)
 target_link_libraries(tfix lofarstman)
+
 add_executable(tLofarStMan tLofarStMan.cc)
+target_include_directories(tLofarStMan PRIVATE ${CASACORE_INCLUDE_DIR})
 target_compile_features(tLofarStMan PRIVATE cxx_std_11)
 target_link_libraries(tLofarStMan lofarstman)
+
 add_executable(tIOPerf tIOPerf.cc)
+target_include_directories(tIOPerf PRIVATE ${CASACORE_INCLUDE_DIR})
 target_compile_features(tIOPerf PRIVATE cxx_std_11)
 target_link_libraries(tIOPerf lofarstman)
 


### PR DESCRIPTION
FIxes #10 by appending CMAKE_MODULE_PATH rather then overwriting.

Use as follows:

```CMake
find_package(LofarStMan QUIET)

if(NOT LofarStMan_FOUND)
    set(ORIG_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
    list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")  #change for FindCasacore.cmake path
    FetchContent_Declare(
        LofarStMan
        GIT_REPOSITORY https://github.com/Dantali0n/LofarStMan.git
        GIT_TAG fix-fetchconten
    )
    FetchContent_MakeAvailable(LofarStMan)
    set(CMAKE_MODULE_PATH ${ORIG_CMAKE_MODULE_PATH})
endif()
```