### PR TITLE
Use Ubuntu 26.04, because we need proper C++20 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,17 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Apt install required packages
       run: |
-        sudo apt update && sudo apt install -qq -y casacore-dev cmake libhdf5-dev > /dev/null
+        sudo apt update
+        sudo apt install -y casacore-dev cmake libhdf5-dev
     - name: Get measures data
       run: |
         mkdir ${HOME}/casacore-data && pushd ${HOME}/casacore-data
-        wget -q ftp://anonymous@ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar
+        wget -q https://iers.astron.nl/WSRT_Measures.ztar
         tar xf WSRT_Measures.ztar
         echo "measures.directory: ~/casacore-data" > ${HOME}/.casarc
         popd
@@ -24,7 +25,7 @@ jobs:
         cmake ..
         cmake --build .
         popd
-    - name: Test PyBDSF
+    - name: Test LofarStMan
       run: |
         pushd build
         make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ target_include_directories(lofarstman
 	$<INSTALL_INTERFACE:include>
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
-target_compile_features(lofarstman PRIVATE cxx_std_11)
+target_compile_features(lofarstman PRIVATE cxx_std_20)
 
 target_link_libraries(lofarstman PUBLIC ${CASACORE_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-project(LofarStMan VERSION 1.0.1)
+project(LofarStMan VERSION 1.0.2)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR})
 


### PR DESCRIPTION
* Use Ubuntu 26.04, because we need good C++-20 support.
* Updated the download link for the Measures data.
* Un-silenced the `apt install`, so that you can see what's going on.
* Bumped the version the `checkout` action.