### PR TITLE
Use c++20 globally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,17 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Apt install required packages
       run: |
-        sudo apt update && sudo apt install -qq -y casacore-dev cmake libhdf5-dev > /dev/null
+        sudo apt update
+        sudo apt install -y casacore-dev cmake libhdf5-dev
     - name: Get measures data
       run: |
         mkdir ${HOME}/casacore-data && pushd ${HOME}/casacore-data
-        wget -q ftp://anonymous@ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar
+        wget -q https://iers.astron.nl/WSRT_Measures.ztar
         tar xf WSRT_Measures.ztar
         echo "measures.directory: ~/casacore-data" > ${HOME}/.casarc
         popd
@@ -24,7 +25,7 @@ jobs:
         cmake ..
         cmake --build .
         popd
-    - name: Test PyBDSF
+    - name: Test LofarStMan
       run: |
         pushd build
         make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,16 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v4
     - name: Apt install required packages
       run: |
-        sudo apt update
-        sudo apt install -y casacore-dev cmake libhdf5-dev
+        sudo apt update && sudo apt install -qq -y casacore-dev cmake libhdf5-dev > /dev/null
     - name: Get measures data
       run: |
         mkdir ${HOME}/casacore-data && pushd ${HOME}/casacore-data
-        wget -q https://iers.astron.nl/WSRT_Measures.ztar
+        wget -q ftp://anonymous@ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar
         tar xf WSRT_Measures.ztar
         echo "measures.directory: ~/casacore-data" > ${HOME}/.casarc
         popd
@@ -25,7 +24,7 @@ jobs:
         cmake ..
         cmake --build .
         popd
-    - name: Test LofarStMan
+    - name: Test PyBDSF
       run: |
         pushd build
         make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-project(LofarStMan VERSION 1.0.2)
+project(LofarStMan VERSION 1.0.1)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR})
 
@@ -30,7 +30,7 @@ target_include_directories(lofarstman
 	$<INSTALL_INTERFACE:include>
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
-target_compile_features(lofarstman PRIVATE cxx_std_20)
+target_compile_features(lofarstman PRIVATE cxx_std_11)
 
 target_link_libraries(lofarstman PUBLIC ${CASACORE_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,10 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-project(LofarStMan VERSION 1.0.1)
+project(LofarStMan VERSION 1.0.2)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR})
 
@@ -30,7 +33,6 @@ target_include_directories(lofarstman
 	$<INSTALL_INTERFACE:include>
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
-target_compile_features(lofarstman PRIVATE cxx_std_11)
 
 target_link_libraries(lofarstman PUBLIC ${CASACORE_LIBRARIES})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,13 +3,10 @@
 include_directories($<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 
 add_executable(tfix tfix.cc)
-target_compile_features(tfix PRIVATE cxx_std_11)
 target_link_libraries(tfix lofarstman)
 add_executable(tLofarStMan tLofarStMan.cc)
-target_compile_features(tLofarStMan PRIVATE cxx_std_11)
 target_link_libraries(tLofarStMan lofarstman)
 add_executable(tIOPerf tIOPerf.cc)
-target_compile_features(tIOPerf PRIVATE cxx_std_11)
 target_link_libraries(tIOPerf lofarstman)
 
 add_test(tfix tfix)


### PR DESCRIPTION
Use C++-20 language features globally, because the latest (yet unreleased) version of `casacore` requires its use.

The per-target C++-11 language feature settings have been removed and replaced with a global setting, basically because the requirement to use C++-20 is externally put on us. Using a per-target setting would give the impression that the requirement is for that specific target, yet that is not the case. A per-target setting also incurs extra maintenance overhead, if `casacore` at some stage would require C++-23 language features.

Note that this PR reverts some of the changes made in PR #15.

**Note**:
Another way to solve the issue is to modify the line https://github.com/lofar-astron/LofarStMan/blob/c10616c9f7f5b5dfa26ff46c9298c27654aabefd/CMakeLists.txt#L33 to:
```
target_compile_features(lofarstman PUBLIC cxx_std_20)
```
That would still require the removal of the `target_compile_feature()` lines in `test/CMakeLists.txt`
I'm happy to go that way, if that's considered more desirable, but I still believe it gives off the wrong signal about the language feature requirements of `LofarStMan` itself.