### PR TITLE
Fix bug in test

### DIFF
--- a/test/tLofarStMan.cc
+++ b/test/tLofarStMan.cc
@@ -413,7 +413,7 @@ void readTable (uInt nseq, uInt nant, uInt nchan, uInt npol,
   // Open the table and check if #rows is as expected.
   Table tab("tLofarStMan_tmp.data");
   uInt nrow = tab.nrow();
-  AlwaysAssertExit (nrow = nseq*nbasel);
+  AlwaysAssertExit (nrow == nseq*nbasel);
   AlwaysAssertExit (!tab.canAddRow());
   AlwaysAssertExit (!tab.canRemoveRow());
   AlwaysAssertExit (tab.canRemoveColumn(Vector<String>(1, "DATA")));


### PR DESCRIPTION
One of the `assert` checks contained an assignment (`=`), instead of a comparison (`==`). This has been fixed.